### PR TITLE
feat: Add card type support for Planka 2.0

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -56,6 +56,7 @@ export const PlankaCardSchema = z.object({
   id: z.string(),
   listId: z.string(),
   name: z.string(),
+  type: z.enum(["project", "task"]).optional(),
   description: z.string().nullable(),
   position: z.number(),
   dueDate: z.string().nullable(),

--- a/index.ts
+++ b/index.ts
@@ -256,6 +256,7 @@ server.tool(
       .optional()
       .describe("The ID of the project (if moving between projects)"),
     name: z.string().optional().describe("The name of the card"),
+    type: z.enum(["project", "task"]).optional().describe("The type of the card (project or task, defaults to project)"),
     description: z.string().optional().describe("The description of the card"),
     position: z.number().optional().describe("The position of the card"),
     dueDate: z
@@ -297,6 +298,7 @@ server.tool(
         result = await cards.createCard({
           listId: args.listId,
           name: args.name,
+          type: args.type || "project",
           description: args.description || "",
           position: args.position || 0,
         });
@@ -357,6 +359,7 @@ server.tool(
         result = await createCardWithTasks({
           listId: args.listId,
           name: args.name,
+          type: args.type || "project",
           description: args.description,
           tasks: args.tasks,
           comment: args.comment,

--- a/operations/cards.ts
+++ b/operations/cards.ts
@@ -21,6 +21,7 @@ import { PlankaCardSchema, PlankaStopwatchSchema } from "../common/types.js";
 export const CreateCardSchema = z.object({
     listId: z.string().describe("List ID"),
     name: z.string().describe("Card name"),
+    type: z.enum(["project", "task"]).default("project").describe("Card type (project or task)"),
     description: z.string().optional().describe("Card description"),
     position: z.number().optional().describe("Card position (default: 65535)"),
 });
@@ -142,6 +143,7 @@ export async function createCard(options: CreateCardOptions) {
                 method: "POST",
                 body: {
                     name: options.name,
+                    type: options.type || "project",
                     description: options.description,
                     position: options.position,
                 },
@@ -344,6 +346,7 @@ export async function duplicateCard(id: string, position?: number) {
         const newCard = await createCard({
             listId,
             name: cardName,
+            type: originalCard.type || "project",
             description: originalCard.description || "",
             position: position || 65535,
         });

--- a/operations/labels.ts
+++ b/operations/labels.ts
@@ -283,9 +283,9 @@ export async function deleteLabel(id: string) {
  */
 export async function addLabelToCard(cardId: string, labelId: string) {
     try {
-        // The correct endpoint is /api/cards/{cardId}/labels with labelId in the body
+        // Planka 2.0 uses /api/cards/{cardId}/card-labels endpoint
         await plankaRequest(
-            `/api/cards/${cardId}/labels`,
+            `/api/cards/${cardId}/card-labels`,
             {
                 method: "POST",
                 body: {
@@ -313,9 +313,9 @@ export async function addLabelToCard(cardId: string, labelId: string) {
  */
 export async function removeLabelFromCard(cardId: string, labelId: string) {
     try {
-        // The correct endpoint is /api/cards/{cardId}/labels/{labelId}
+        // Planka 2.0 uses /api/cards/{cardId}/card-labels/labelId:{labelId} endpoint
         await plankaRequest(
-            `/api/cards/${cardId}/labels/${labelId}`,
+            `/api/cards/${cardId}/card-labels/labelId:${labelId}`,
             {
                 method: "DELETE",
             },

--- a/tools/create-card-with-tasks.ts
+++ b/tools/create-card-with-tasks.ts
@@ -15,6 +15,7 @@ import { createComment } from "../operations/comments.js";
 export const createCardWithTasksSchema = z.object({
     listId: z.string().describe("The ID of the list to create the card in"),
     name: z.string().describe("The name of the card"),
+    type: z.enum(["project", "task"]).default("project").describe("Card type (project or task)"),
     description: z.string().optional().describe("The description of the card"),
     tasks: z.array(z.string()).optional().describe(
         "Array of task descriptions to create",
@@ -51,7 +52,7 @@ export type CreateCardWithTasksParams = z.infer<
  * @throws {Error} If there's an error creating the card, tasks, or comment
  */
 export async function createCardWithTasks(params: CreateCardWithTasksParams) {
-    const { listId, name, description, tasks, comment, position = 65535 } =
+    const { listId, name, type = "project", description, tasks, comment, position = 65535 } =
         params;
 
     try {
@@ -59,6 +60,7 @@ export async function createCardWithTasks(params: CreateCardWithTasksParams) {
         const card = await createCard({
             listId,
             name,
+            type,
             description: description || "",
             position,
         });


### PR DESCRIPTION
## Summary

Planka 2.0 (starting from rc.4) requires a \	ype\ field when creating cards. Without this field, the API returns an error about missing parameters.

The type can be \project\ or \	ask\ and defaults to \project\.

## Changes

- Add \	ype\ field to \PlankaCardSchema\ in \common/types.ts\
- Add \	ype\ parameter to \CreateCardSchema\ and \createCard()\ function in \operations/cards.ts\
- Add \	ype\ parameter to \createCardWithTasks()\ function in \	ools/create-card-with-tasks.ts\
- Pass \	ype\ in card creation, duplication, and \create_with_tasks\ actions
- Expose \	ype\ parameter in \mcp_kanban_card_manager\ tool in \index.ts\

## Testing

Tested with Planka 2.0.0-rc.4. Card creation now works correctly.

## Related

- Planka 2.0.0-rc.4 release: https://github.com/plankanban/planka/releases/tag/v2.0.0-rc.4